### PR TITLE
fix: Fix automatic release pipeline by using correct github token for basic git operations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
### This PR
* makes use of the keptn-bot token for repo checkout in the release pipeline. This fixes the issue where pushes to the protected main branch for releases were not allowed