### PR TITLE
feat: Add semantic PR/commit check workflow

### DIFF
--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -1,0 +1,49 @@
+name: Semantic PR Validation
+on:
+  workflow_call:
+    inputs:
+      scopes:
+        type: string
+        description: 'Configure which scopes are allowed.'
+        required: false
+        default: ''
+      types:
+        type: string
+        description: 'Configure which types are allowed (see https://github.com/commitizen/conventional-commit-types).'
+        required: false
+        default: |
+            feat
+            fix
+            build
+            chore
+            ci
+            docs
+            perf
+            refactor
+            revert
+            style
+            test
+defaults:
+  run:
+    shell: bash
+jobs:
+  validate:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Validate Pull Request
+        uses: amannn/action-semantic-pull-request@7bfb19c48fc334d3dacb072cf982e81535041209 # pin@v3.4.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed.
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: ${{ inputs.types }}
+          # Configure which scopes are allowed.
+          scopes: ${{ inputs.scopes }}
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one commit PRs.
+          validateSingleCommit: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repo contains shared GitHub Actions workflows that are used by multiple repos under the Keptn GitHub organization.
 
 ## Workflows
-| Name | Filename | Description | Inputs | Outputs |
-|------|----------|-------------|--------|---------|
-| DCO | `dco.yml` | Checks the [Developer Certificate of Origin](https://developercertificate.org/) on a PR or on a default branch. | - `exclude-emails`: Comma-separated list of emails that should be ignored during DCO checks | None |
+| Name                 | Filename                   | Description | Inputs | Outputs |
+|----------------------|----------------------------|-------------|--------|---------|
+| DCO                  | `dco.yml`                  | Checks the [Developer Certificate of Origin](https://developercertificate.org/) on a PR or on a default branch. |`exclude-emails`: Comma-separated list of emails that should be ignored during DCO checks | None |
+| Validate Semantic PR | `validate-semantic-pr.yml` | Checks for [Semantic PR messages](https://www.conventionalcommits.org/en/v1.0.0/) in order to enhance release note generation | `types`: List of types <br/>`scopes`: List of scopes | None |
+


### PR DESCRIPTION
## This PR

- Adds the semantic PR/commit check workflow (with some default types)

Usage Example:
```
name: Semantic PR Validation
on:
  pull_request_target:
    types:
      - opened
      - edited
      - synchronize
jobs:
  validate:
    uses: keptn/gh-automation/.github/workflows/validate-semantic-pr.yml@feature/semantic-pr
    with:
      # Configure which scopes are allowed.
      scopes: |
        api
        cli
        core
        install
        cloudevents
        deps
        deps-dev
        distributor
        docs
        release
```
