### PR TITLE
feat: Add pre-release and release workflow for integrations

### DIFF
--- a/.github/workflows/pre-release-integration.yml
+++ b/.github/workflows/pre-release-integration.yml
@@ -1,0 +1,67 @@
+name: Pre-release integration
+on:
+  workflow_call:
+    inputs:
+      PRERELEASE_KEYWORD:
+        description: "Pre release keyword, e.g., next"
+        required: false
+        type: string
+        default: "next"
+    outputs:
+      RELEASE_TAG:
+        description: "Release Tag for Github release"
+        value: ${{ jobs.pre-release.outputs.tag-name }}
+defaults:
+  run:
+    shell: bash
+env:
+  NODE_VERSION: 14 # needed for npx
+  RELEASE_NOTES_FILE: "RELEASE-BODY.md"
+  PRERELEASE_KEYWORD: ${{ inputs.PRERELEASE_KEYWORD }}
+jobs:
+  pre-release:
+    runs-on: ubuntu-20.04
+    outputs:
+      tag-name: ${{ steps.create-release-package.outputs.tag-name }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js # needed for npx
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions" # "${{ github.actor }}"
+          git config user.email "actions@github.com" # "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Prepare GitHub Release Notes
+        run: |
+          npx standard-version@^9.3.1 --prerelease "${{ env.PRERELEASE_KEYWORD }}" -i "${{ env.RELEASE_NOTES_FILE }}" --skip.commit --skip.tag --header ""
+
+      - name: Enhance Release Notes with Build Metadata
+        run: |
+          echo "#### Build Information" >> "${{ env.RELEASE_NOTES_FILE }}"
+          echo "" >> "${{ env.RELEASE_NOTES_FILE }}"
+          echo "**GitHub Actions Run:** $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${{ env.RELEASE_NOTES_FILE }}"
+
+      - name: Create pre-release package
+        id: create-release-package
+        run: |
+          echo "🚀 Creating pre-release package now..."
+          npx standard-version@^9.3.1 --prerelease "${{ env.PRERELEASE_KEYWORD }}" --skip.commit --skip.changelog
+
+          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
+          echo "⚡️ Pushing changes to remote repository..."
+          git push --follow-tags
+
+      - name: Create GitHub Release
+        env:
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$RELEASE_TAG" --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -1,0 +1,94 @@
+name: Release integration
+on:
+  workflow_call:
+    outputs:
+      RELEASE_TAG:
+        description: "Release Tag for Github release"
+        value: ${{ jobs.pre-release.outputs.tag-name }}
+defaults:
+  run:
+    shell: bash
+env:
+  NODE_VERSION: 14 # needed for npx
+  RELEASE_NOTES_FILE: "RELEASE-BODY.md"
+jobs:
+  pre-release:
+    runs-on: ubuntu-20.04
+    outputs:
+      tag-name: ${{ steps.create-release-package.outputs.tag-name }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions" # "${{ github.actor }}"
+          git config user.email "actions@github.com" # "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Prepare GitHub Release Notes
+        run: |
+          # Delete pre-release tags to be able to generate a changelog from last 'real' release LOCALLY
+          # This is a workaround for a known limitation of standard-version
+          # Reference: https://github.com/conventional-changelog/standard-version/issues/203#issuecomment-872415140
+          git tag -l | grep -vE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' | xargs git tag -d
+
+          # generate release notes into RELEASE_NOTES_FILE
+          npx standard-version@^9.3.1 -i "${{ env.RELEASE_NOTES_FILE }}" --skip.commit --skip.tag --header ""          
+
+      - name: Create release package
+        id: create-release-package
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🚀 Creating release package now..."
+          # this will generate a commit and a tag
+          npx standard-version@^9.3.1 --skip.commit
+
+          TAG=$(git describe --tags --abbrev=0)
+
+          # determine tag name
+          echo "::set-output name=tag-name::$TAG"
+
+          # create a commit with the changelog
+          git add CHANGELOG.md
+          git commit -s -m "chore(release): $TAG"
+
+      - name: Push changes to repo
+        id: push-changes
+        env:
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Fetching previously deleted old tags..."
+          git fetch origin --tags -f
+          TARGET_BRANCH=patch/release-notes-$RELEASE_TAG
+          # delete existing branch just in case
+          git branch -D $TARGET_BRANCH &>/dev/null || true
+          # create new branch
+          git checkout -b $TARGET_BRANCH
+          # push changes
+          echo "⚡️ Pushing changes to remote repository..."
+          git push -f --follow-tags --set-upstream origin patch/release-notes-$RELEASE_TAG
+
+
+      - name: Create GitHub Pull Request for release notes
+        env:
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create --title "chore: Release notes for $RELEASE_TAG" --body "**This is an automated PR for release notes of $RELEASE_TAG!**"
+
+
+      - name: Create GitHub Release
+        env:
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$RELEASE_TAG" --draft --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -58,7 +58,7 @@ jobs:
 
           # create a commit with the changelog
           git add CHANGELOG.md
-          git commit -s -m "chore(release): $TAG"
+          git commit -s -m "build(release): $TAG"
 
       - name: Push changes to repo
         id: push-changes

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 This repo contains shared GitHub Actions workflows that are used by multiple repos under the Keptn GitHub organization.
 
 ## Workflows
-| Name                 | Filename                   | Description | Inputs | Outputs |
-|----------------------|----------------------------|-------------|--------|---------|
-| DCO                  | `dco.yml`                  | Checks the [Developer Certificate of Origin](https://developercertificate.org/) on a PR or on a default branch. |`exclude-emails`: Comma-separated list of emails that should be ignored during DCO checks | None |
-| Validate Semantic PR | `validate-semantic-pr.yml` | Checks for [Semantic PR messages](https://www.conventionalcommits.org/en/v1.0.0/) in order to enhance release note generation | `types`: List of types <br/>`scopes`: List of scopes | None |
-
+| Name                    | Filename                      | Description | Inputs | Outputs |
+|-------------------------|-------------------------------|-------------|--------|---------|
+| DCO                     | `dco.yml`                     | Checks the [Developer Certificate of Origin](https://developercertificate.org/) on a PR or on a default branch. |`exclude-emails`: Comma-separated list of emails that should be ignored during DCO checks | None |
+| Validate Semantic PR    | `validate-semantic-pr.yml`    | Checks for [Semantic PR messages](https://www.conventionalcommits.org/en/v1.0.0/) in order to enhance release note generation | `types`: List of types <br/>`scopes`: List of scopes | None |
+| Pre-Release Integration | `pre-release-integration.yml` | Creates a pre-release of a Keptn integration | `PRERELEASE_KEYWORD`: Keyword for pre-releases, e.g., `alpha`, `next` | `RELEASE_TAG` |
+| Release Integration     | `release-integration.yml`     | Creates a release of a Keptn integration | None | `RELEASE_TAG` |


### PR DESCRIPTION
## This PR

- Adds a pre-release and release workflow for Keptn integrations

## Usage Example (pre-)release workflow

```yaml
name: Create Pre-Release
on:
  workflow_dispatch:
jobs:
  test:
    strategy:
      matrix:
        platform: [ubuntu-latest]
    runs-on: ${{ matrix.platform }}
    steps:
      - name: Checkout code
        uses: actions/checkout@v2.3.4
      - name: Run tests
        run: echo "No tests configured yet"

  pre-release:
    needs: test
    name: Pre-Release
    uses: keptn/gh-automation/.github/workflows/pre-release-integration.yml@feature/integration-workflows
    # pre-release and release workflow are interchangeable here!

  release-assets:
    name: Release Assets
    needs: pre-release
    runs-on: ubuntu-latest
    steps:
      - name: Checkout code
        uses: actions/checkout@v2.3.4
      - name: Add release assets
        env:
          RELEASE_TAG: ${{ needs.pre-release.outputs.RELEASE_TAG }}
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          gh release upload "$RELEASE_TAG" ./LICENSE

```
