### PR TITLE
feat: Added input for pull and push on docker build

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -28,6 +28,14 @@ inputs:
     description: "Target to be built using docker build"
     required: false
     default: ''
+  PULL:
+    description: "Whether or not to pull the image before building (i.e., to make use of cached layers)"
+    required: false
+    default: 'false'    
+  PUSH:
+    description: "Whether or not to push the image to the desired registry"
+    required: false
+    default: 'true'
 outputs:
   BUILD_METADATA:
     description: Docker Build metadata 
@@ -67,6 +75,6 @@ runs:
         context: .
         tags: ${{ inputs.TAGS }}
         build-args: ${{ inputs.BUILD_ARGS }}
-        push: true
-        pull: false
+        push: ${{ inputs.PUSH }}
+        pull: ${{ inputs.PULL }}
         target: ${{ inputs.TARGET }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The following re-usable actions are available:
 * `GITHUB_TOKEN`: Github Access token used for pushing to ghcr.io - leave empty if you don't want to push to ghcr.io
 * `DOCKERFILE`: Dockerfile to be used in docker build
 * `TARGET`: Target to be built using docker build
+* `PULL`: Whether or not to pull the image before building (i.e., to make use of cached layers)
+* `PUSH`: Whether or not to push the image to the desired registries
 
 **Outputs**:
 * `BUILD_METADATA`: Docker build Metadata, see [Docker Build Push Action Docs](https://github.com/docker/build-push-action#outputs)


### PR DESCRIPTION
## This PR

- Adds the two input fields `PUSH` and `PULL` to the docker build action

This allows more advanced workflow configuration, e.g.:

```
      - name: Docker Build
        id: docker_build
        uses: keptn/gh-automation/.github/actions/docker-build@main
        with:
          TAGS: |
            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.VERSION }}
            ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE_INITCONTAINER }}:${{ env.VERSION }}
          BUILD_ARGS: |
            version=${{ env.VERSION }}
            datetime=${{ env.DATETIME }}
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
          PUSH: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
```