### PR TITLE
feat: added prepare-ci workflow

### DIFF
--- a/.github/workflows/prepare-ci.yml
+++ b/.github/workflows/prepare-ci.yml
@@ -1,0 +1,114 @@
+name: Prepare CI Run
+on:
+  workflow_call:
+    outputs:
+      BRANCH:
+        description: Name of the branch that is currently being built
+        value: ${{ jobs.prepare_ci_run.outputs.BRANCH }}
+      BRANCH_SLUG:
+        description: Slug-name of the branch that is currently being built
+        value: ${{ jobs.prepare_ci_run.outputs.BRANCH_SLUG }}
+      VERSION:
+        description: Version that the next build should have (e.g., for tagging docker images)
+        value: ${{ jobs.prepare_ci_run.outputs.VERSION }}
+      DATETIME:
+        description: Current date and time (e.g., for tagging docker images)
+        value: ${{ jobs.prepare_ci_run.outputs.DATETIME }}
+      GIT_SHA:
+        description: Hash of the current git commit that this CI run is based on
+        value: ${{ jobs.prepare_ci_run.outputs.GIT_SHA }}
+defaults:
+  run:
+    shell: bash
+jobs:
+  prepare_ci_run:
+    name: Prepare CI Run
+    # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
+    # built afterwards (in other jobs that depend on this one).
+    runs-on: ubuntu-20.04
+    outputs:
+      BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
+      BRANCH_SLUG: ${{ steps.extract_branch.outputs.BRANCH_SLUG }}
+      VERSION: ${{ steps.get_version.outputs.VERSION }}
+      DATETIME: ${{ steps.get_datetime.outputs.DATETIME }}
+      GIT_SHA: ${{ steps.extract_branch.outputs.GIT_SHA }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Extract branch name
+        id: extract_branch
+        run: |
+          echo "Note: GITHUB_REF=${GITHUB_REF}"
+
+          if [[ "${GITHUB_REF}" == "refs/heads"* ]]; then
+              echo "Note: This is a push to a local branch -> using branch name"
+              BRANCH=${GITHUB_REF#refs/heads/}
+              BRANCH_SLUG=$(echo $BRANCH | iconv -t ascii//TRANSLIT | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z)
+          else
+              if [[ "${GITHUB_REF}" == "refs/pull/"* ]]; then
+                  # usually the format for PRs is: refs/pull/1234/merge
+                  echo "Note: This is a Pull Request -> using PR ID"
+                  tmp=${GITHUB_REF#refs/pull/}
+                  # remove the last "/merge"
+                  # Branch name is basically the PR id
+                  BRANCH=PR-${tmp%/merge}
+                  # And Slug is "PR-${PRID}"
+                  BRANCH_SLUG=${BRANCH}
+              else
+                  echo "::error This is neither a push, nor a PR, probably something else... Exiting"
+                  exit 1
+              fi
+          fi
+          GIT_SHA="$(git rev-parse --short HEAD)"
+
+          # print GIT_SHA, BRANCH and BRANCH_SLUG (make sure they are also set in needs.prepare_ci_run.outputs !!!)
+          echo "##[set-output name=BRANCH;]$(echo ${BRANCH})"
+          echo "##[set-output name=BRANCH_SLUG;]$(echo ${BRANCH_SLUG})"
+          echo "##[set-output name=GIT_SHA;]$(echo ${GIT_SHA})"
+
+      - name: 'Get Previous tag'
+        id: get_previous_tag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      - name: 'Get next patch version'
+        id: get_next_semver_tag
+        uses: "WyriHaximus/github-action-next-semvers@v1"
+        with:
+          version: ${{ steps.get_previous_tag.outputs.tag }}
+
+      - name: Determine next version
+        id: get_version
+        env:
+          BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
+          BRANCH_SLUG: ${{ steps.extract_branch.outputs.BRANCH_SLUG }}
+        shell: bash
+        run: |
+          # determine version
+          GIT_LAST_TAG=${{ steps.get_previous_tag.outputs.tag }}
+          GIT_NEXT_TAG=${{ steps.get_next_semver_tag.outputs.patch }}
+          echo "GIT_LAST_TAG=${GIT_LAST_TAG}, GIT_NEXT_TAG=${GIT_NEXT_TAG}"
+
+          if [[ "$BRANCH" == "release-"* ]]; then
+            # Release Branch: extract version from branch name
+            VERSION=${BRANCH#"release-"}
+            else
+            if [[ "$BRANCH" == "master" ]]; then
+              # master branch = latest
+              VERSION="${GIT_NEXT_TAG}-dev"
+            else
+              # Feature/Development Branch - use last tag with branch slug
+              VERSION="${GIT_NEXT_TAG}-dev-${BRANCH_SLUG}"
+            fi
+          fi
+
+          echo "VERSION=${VERSION}"
+
+          echo "##[set-output name=VERSION;]$(echo ${VERSION})"
+
+      - name: Get current date and time
+        id: get_datetime
+        run: |
+          echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following re-usable workflows are available:
 | Validate Semantic PR    | `validate-semantic-pr.yml`    | Checks for [Semantic PR messages](https://www.conventionalcommits.org/en/v1.0.0/) in order to enhance release note generation | `types`: List of types <br/>`scopes`: List of scopes | None |
 | Pre-Release Integration | `pre-release-integration.yml` | Creates a pre-release of a Keptn integration | `PRERELEASE_KEYWORD`: Keyword for pre-releases, e.g., `alpha`, `next` | `RELEASE_TAG` |
 | Release Integration     | `release-integration.yml`     | Creates a release of a Keptn integration | None | `RELEASE_TAG` |
+| Prepare CI Run          | `prepare-ci.yml`              | Determines Git Commit Hash, next version, Datetime | None | `BRANCH`<br/>`BRANCH_SLUG`<br/>`VERSION`<br/>`DATETIME`<br/>`GIT_SHA` |
 
 ## Actions
 


### PR DESCRIPTION
## This PR

- adds the prepare-ci workflow which is heavily used in keptn-contrib and keptn-sandbox, but also in keptn/keptn

Example usage:

```
  prepare_ci_run:
    name: Prepare CI Run
    uses: keptn/gh-automation/.github/workflows/prepare-ci.yml@feat/prepare_ci

...
  ############################################################################
  # Build Docker Image                                                      #
  ############################################################################
  docker_build:
    needs: [prepare_ci_run]
    name: Docker Build
    runs-on: ubuntu-20.04
    env:
      VERSION: ${{ needs.prepare_ci_run.outputs.VERSION }}
      DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
    steps:
...
      - name: Docker Build
        id: docker_build
        uses: keptn/gh-automation/.github/actions/docker-build@v1.3.0
        with:
          TAGS: |
            ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}:${{ env.VERSION }}
            ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}:${{ env.VERSION }}.${{ env.DATETIME }}

```
