### PR TITLE
fix: release integration workflow needs to create a PR towards the github_ref

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -83,7 +83,7 @@ jobs:
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr create --title "chore: Release notes for $RELEASE_TAG" --body "**This is an automated PR for release notes of $RELEASE_TAG!**"
+          gh pr create --title "chore: Release notes for $RELEASE_TAG" --body "**This is an automated PR for release notes of $RELEASE_TAG!**" --base "${GITHUB_REF##*/}"
 
 
       - name: Create GitHub Release


### PR DESCRIPTION
Fixes #11 

**Proof it works**

**Patch release 5.1.x**
![image](https://user-images.githubusercontent.com/56065213/150995570-6f48a543-152b-4e9b-a208-9afc3d810e7f.png)

**Major release 6.0.0**
![image](https://user-images.githubusercontent.com/56065213/150995640-099dc51c-5bf7-4752-91c1-733c3ba7d3fd.png)
