### PR TITLE
feat: Add ability to toggle draft release creation for release-integration workflow

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -3,10 +3,10 @@ on:
   workflow_call:
     inputs:
       draft:
-        type: string
+        type: boolean
         description: 'Whether or not a draft release should be created (default: true)'
         required: false
-        default: 'true'
+        default: true
     outputs:
       RELEASE_TAG:
         description: "Release Tag for Github release"
@@ -17,7 +17,6 @@ defaults:
 env:
   NODE_VERSION: 14 # needed for npx
   RELEASE_NOTES_FILE: "RELEASE-BODY.md"
-  CREATE_DRAFT_RELEASE: ${{ inputs.draft }}
 jobs:
   pre-release:
     runs-on: ubuntu-20.04
@@ -98,9 +97,4 @@ jobs:
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PARAMS=""
-          if [[ "${CREATE_DRAFT_RELEASE}" == "true" ]]; then
-            PARAMS="--draft "
-          fi
-
-          gh release create "$RELEASE_TAG" $PARAMS --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
+          gh release create "$RELEASE_TAG" --draft=${{ inputs.draft }} --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -1,6 +1,12 @@
 name: Release integration
 on:
   workflow_call:
+    inputs:
+      draft:
+        type: string
+        description: 'Whether or not a draft release should be created (default: true)'
+        required: false
+        default: 'true'
     outputs:
       RELEASE_TAG:
         description: "Release Tag for Github release"
@@ -11,6 +17,7 @@ defaults:
 env:
   NODE_VERSION: 14 # needed for npx
   RELEASE_NOTES_FILE: "RELEASE-BODY.md"
+  CREATE_DRAFT_RELEASE: ${{ inputs.draft }}
 jobs:
   pre-release:
     runs-on: ubuntu-20.04
@@ -91,4 +98,9 @@ jobs:
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "$RELEASE_TAG" --draft --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"
+          PARAMS=""
+          if [[ "${CREATE_DRAFT_RELEASE}" == "true" ]]; then
+            PARAMS="--draft "
+          fi
+
+          gh release create "$RELEASE_TAG" $PARAMS --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following re-usable workflows are available:
 | DCO                     | `dco.yml`                     | Checks the [Developer Certificate of Origin](https://developercertificate.org/) on a PR or on a default branch. |`exclude-emails`: Comma-separated list of emails that should be ignored during DCO checks | None |
 | Validate Semantic PR    | `validate-semantic-pr.yml`    | Checks for [Semantic PR messages](https://www.conventionalcommits.org/en/v1.0.0/) in order to enhance release note generation | `types`: List of types <br/>`scopes`: List of scopes | None |
 | Pre-Release Integration | `pre-release-integration.yml` | Creates a pre-release of a Keptn integration | `PRERELEASE_KEYWORD`: Keyword for pre-releases, e.g., `alpha`, `next` | `RELEASE_TAG` |
-| Release Integration     | `release-integration.yml`     | Creates a release of a Keptn integration | None | `RELEASE_TAG` |
+| Release Integration     | `release-integration.yml`     | Creates a (draft) release of a Keptn integration | `draft` (default: true) | `RELEASE_TAG` |
 | Prepare CI Run          | `prepare-ci.yml`              | Determines Git Commit Hash, next version, Datetime | None | `BRANCH`<br/>`BRANCH_SLUG`<br/>`VERSION`<br/>`DATETIME`<br/>`GIT_SHA` |
 
 ## Actions


### PR DESCRIPTION
Implements #13 

It is now possible to use the workflow like this:
```
  release:
    needs: test
    name: Release
    uses: keptn/gh-automation/.github/workflows/release-integration.yml@feature/13/draft-release
    with:
      draft: false
```