### PR TITLE
fix: Normalize docker tags

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -1,8 +1,5 @@
 name: 'Docker Build Push'
 description: 'Docker build and Push'
-defaults:
-  run:
-    shell: bash
 inputs:
   TAGS:
     description: "List of images/tags to be pushed, e.g., keptncontrib/my-service:1.2.3"
@@ -71,6 +68,7 @@ runs:
         env-file: .ci_env
 
     - name: Normalize TAGS
+      shell: bash
       id: normalize_tags
       run: echo "::set-output name=tags::$(echo '${{ inputs.TAGS }}' | tr '[:upper:]' '[:lower:]')"
 

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -67,13 +67,18 @@ runs:
       with:
         env-file: .ci_env
 
+    - name: Normalize TAGS
+      shell: bash
+      id: normalize_tags
+      run:  echo "::set-output name=tags::$(echo ${{ inputs.TAGS }} | tr '[:upper:]' '[:lower:]')"
+
     - id: docker_build_image
       name: "Docker Build"
       uses: docker/build-push-action@v2
       with:
         file: ${{ inputs.DOCKERFILE }}
         context: .
-        tags: ${{ inputs.TAGS }}
+        tags: ${{ steps.normalize_tags.outputs.tags }}
         build-args: ${{ inputs.BUILD_ARGS }}
         push: ${{ inputs.PUSH }}
         pull: ${{ inputs.PULL }}

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -1,5 +1,8 @@
 name: 'Docker Build Push'
 description: 'Docker build and Push'
+defaults:
+  run:
+    shell: bash
 inputs:
   TAGS:
     description: "List of images/tags to be pushed, e.g., keptncontrib/my-service:1.2.3"
@@ -68,7 +71,6 @@ runs:
         env-file: .ci_env
 
     - name: Normalize TAGS
-      shell: bash
       id: normalize_tags
       run: echo "::set-output name=tags::$(echo '${{ inputs.TAGS }}' | tr '[:upper:]' '[:lower:]')"
 

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -70,7 +70,7 @@ runs:
     - name: Normalize TAGS
       shell: bash
       id: normalize_tags
-      run:  echo "::set-output name=tags::$(echo ${{ inputs.TAGS }} | tr '[:upper:]' '[:lower:]')"
+      run: echo "::set-output name=tags::$(echo '${{ inputs.TAGS }}' | tr '[:upper:]' '[:lower:]')"
 
     - id: docker_build_image
       name: "Docker Build"


### PR DESCRIPTION
This PR fixes and issue in the CI pipeline if a GitHub user has any uppercase letters in their name (e.g. `Raffy23`). This is done by transforming all TAGS to lowercase to ensure that all tags are lowercase.

The Problem occurs when using the following docker-build action:
```
     - name: Docker Build
        id: docker_build
        uses: keptn/gh-automation/.github/actions/docker-build
        with:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          TAGS: |
            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE }}:${{ env.VERSION }}
          BUILD_ARGS: |
            version=${{ env.VERSION }}
```
the action will fail with
```
buildx failed with: error: invalid tag "ghcr.io/Raffy23/automatic-octo-telegram:0.0.2-dev": repository name must be lowercase
```

A successful run of the GitHub Action can be seen here: https://github.com/Raffy23/automatic-octo-telegram/actions/runs/1944722398.