### PR TITLE
fix: Fix base branch identifier for pull requests in release workflow

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -89,7 +89,7 @@ jobs:
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr create --title "chore: Release notes for $RELEASE_TAG" --body "**This is an automated PR for release notes of $RELEASE_TAG!**" --base "${GITHUB_REF##*/}"
+          gh pr create --title "chore: Release notes for $RELEASE_TAG" --body "**This is an automated PR for release notes of $RELEASE_TAG!**" --base "${GITHUB_REF_NAME}"
 
 
       - name: Create GitHub Release


### PR DESCRIPTION
When releasing from branches containing a `/` the gh CLI call to open a
pull request specified an invalid base branch by passing `--base
"${GITHUB_REF##*/}"` which chomps everything before a `/` in the
current GITHUB_REF (which contains `refs/heads/<branchname>` or
`refs/tags/<tagname>`). This mangles the branch name if it contains a
`/` character so we use GITHUB_REF_NAME instead which does not contain
any `refs` prefix.

Signed-off-by: Paolo Chila <paolo.chila@dynatrace.com>