### PR TITLE
fix: Fix missing tags after tag normalization

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -70,7 +70,12 @@ runs:
     - name: Normalize TAGS
       shell: bash
       id: normalize_tags
-      run: echo "::set-output name=tags::$(echo '${{ inputs.TAGS }}' | tr '[:upper:]' '[:lower:]')"
+      run: |
+        tags=$(echo '${{ inputs.TAGS }}' | tr '[:upper:]' '[:lower:]')
+        tags="${tags//'%'/'%25'}"
+        tags="${tags//$'\n'/'%0A'}"
+        tags="${tags//$'\r'/'%0D'}"
+        echo "::set-output name=tags::$tags"
 
     - id: docker_build_image
       name: "Docker Build"


### PR DESCRIPTION
## This PR
* should fix #17. GitHub Actions doesn't handle multi-line strings very well ([see](https://github.community/t/set-output-truncates-multiline-strings/16852/3)).