### PR TITLE
ci: set only image name as lowercase, leave image tag untouched

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -71,7 +71,7 @@ runs:
       shell: bash
       id: normalize_tags
       run: |
-        tags=$(echo '${{ inputs.TAGS }}' | tr '[:upper:]' '[:lower:]')
+        tags=$(echo '${{ inputs.TAGS }}' | sed 's/^\([^:]*\)\(:.\+\)\?$/\L\1\E\2/')
         tags="${tags//'%'/'%25'}"
         tags="${tags//$'\n'/'%0A'}"
         tags="${tags//$'\r'/'%0D'}"


### PR DESCRIPTION
Change image name to lowercase but leave the optional tag untouched

Signed-off-by: Paolo Chila <paolo.chila@dynatrace.com>